### PR TITLE
danger: 表示可能なノードがない場合は何もせず終了する

### DIFF
--- a/danger-design.md
+++ b/danger-design.md
@@ -13,19 +13,22 @@ flowchart
 
   GetNoAbstraction-->|並行処理|GetRename["リネームされたファイルの一覧を取得"]
 
+  ExistsNode{グラフに<br>表示可能な<br>ノードが...}
+  ExistsNode-->|ない|TypeScripgGraph非表示-->end2((終了))
+  ExistsNode-->|ある|JudgeGraphAmmounts
+  FilterBaseGraph-->|待ち合わせ|ExistsNode
+  GetRename-->|待ち合わせ|ExistsNode
   JudgeGraphAmmounts{"ファイルの削除<br>またはリネームが..."}
-  FilterBaseGraph-->|待ち合わせ|JudgeGraphAmmounts
-  GetRename-->|待ち合わせ|JudgeGraphAmmounts
 
   %% 1つの Graph
   JudgeGraphAmmounts-->|ない|GetDiff["🏷 Head と Base の差分を取り<br>ノードやリレーションに<br>ステータスを付与する"]
   GetDiff-->MergeGraph["Head と Base をマージする"]
-  MergeGraph-->表示する
+  MergeGraph-->表示する-->end3((終了))
 
   %% 2つの Graph
   JudgeGraphAmmounts-->|ある|AddStatusToHead["🏷 Head の Graph に<br>ステータスを付与する"]
   AddStatusToHead-->AddStatusToBase["🏷 Base の Graph に<br>ステータスを付与する"]
-  AddStatusToBase-->Display2Graph["2つの Graph を表示する"]
+  AddStatusToBase-->Display2Graph["2つの Graph を表示する"]-->end4((終了))
 
 
 ```

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -78,6 +78,7 @@ async function makeGraph() {
     renamePromise,
     graphPromise,
   ]);
+  if (headGraph.nodes.length === 0) return;
 
   const hasRenamed = headGraph.nodes.some(headNode =>
     renamed?.map(({ filename }) => filename).includes(headNode.path),


### PR DESCRIPTION
.ts や .tsx に変更がある場合でも、それがそのプロジェクトの tsc でコンパイル対象となっていない場合などにはグラフに差分が出ない。
その場合でも danger では mermaid をコメント出力してしまい、空の mermaid が表示されていた。

これを修正する。

参考PR: https://github.com/ysk8hori/typescript-graph/pull/31
![image](https://user-images.githubusercontent.com/5052869/230396324-981c3849-2bec-4963-9c61-b9f6f806aefd.png)
