### PR TITLE
chore(renovate): automergeをfalseとする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,5 @@
       "excludePackageNames": ["typescript", "eslint", "eslint-config-prettier"],
       "excludePackagePatterns": ["^@typescript-eslint/", "^eslint-plugin"]
     }
-  ],
-  "automerge": true
+  ]
 }


### PR DESCRIPTION
danger-plugin と相互依存なため、両方のautomergeが有効な場合に無限ループするため