### PR TITLE
fix(filtergraph): exclude対象外となったinclude完全一致ノードからのrelationの表示を抑止

### DIFF
--- a/src/graph/filterGraph.spec.data/nodes.json
+++ b/src/graph/filterGraph.spec.data/nodes.json
@@ -75,6 +75,11 @@
     "changeStatus": "not_modified"
   },
   {
+    "path": "src/includeFiles/excludeFiles/dependsFromButInclude.ts",
+    "name": "dependsFromButInclude.ts",
+    "changeStatus": "not_modified"
+  },
+  {
     "path": "src/otherFiles/children/:id.json",
     "name": ":id.json",
     "changeStatus": "not_modified"

--- a/src/graph/filterGraph.spec.data/relations.json
+++ b/src/graph/filterGraph.spec.data/relations.json
@@ -197,6 +197,21 @@
   {
     "kind": "depends_on",
     "from": {
+      "path": "src/includeFiles/excludeFiles/butInclude.ts",
+      "name": "butInclude.ts",
+      "changeStatus": "not_modified"
+    },
+    "to": {
+      "path": "src/includeFiles/excludeFiles/dependsFromButInclude.ts",
+      "name": "dependsFromButInclude.ts",
+      "changeStatus": "not_modified"
+    },
+    "fullText": ";",
+    "changeStatus": "not_modified"
+  },
+  {
+    "kind": "depends_on",
+    "from": {
       "path": "src/includeFiles/a.ts",
       "name": "a.ts",
       "changeStatus": "not_modified"

--- a/src/graph/filterGraph.ts
+++ b/src/graph/filterGraph.ts
@@ -38,17 +38,33 @@ export function filterGraph(
           node.path.toLowerCase().includes(word.toLowerCase()),
         ),
     );
-
-    tmpRelations = tmpRelations.filter(
-      ({ from, to }) =>
-        include.some(word => from.path === word || to.path === word) ||
-        !exclude.some(
-          word =>
-            from.path.toLowerCase().includes(word.toLowerCase()) ||
-            to.path.toLowerCase().includes(word.toLowerCase()),
-        ),
-    );
+    console.log(tmpNodes);
+    tmpRelations = tmpRelations.filter(({ from, to }) => {
+      if (include.some(word => to.path === word)) {
+        // to が include に完全一致する場合は除外しない
+        return true;
+      }
+      if (
+        exclude.some(word =>
+          from.path.toLowerCase().includes(word.toLowerCase()),
+        )
+      ) {
+        // from が exclude に含まれる場合は除外する
+        return false;
+      }
+      if (
+        // to が exclude に含まれる場合は除外する
+        exclude.some(word => to.path.toLowerCase().includes(word.toLowerCase()))
+      ) {
+        return false;
+      }
+      return true;
+    });
   }
+  // 失われた relation の復元。
+  // from と to の両方が include に含まれない relation が手前の処理で除外されるが、
+  // 片方が include に含まれていて残った relation（変数名はtmpRelations） の include 対象外の node 同士が本来繋がっている場合があるので、
+  // それを復元する。
   tmpRelations = getUniqueRelations(
     tmpRelations.concat(
       relations.filter(({ from, to }) => {


### PR DESCRIPTION
exclude指定しているのにexclude対象外のノードと同じ扱いをするのは嬉しくないので。