### PR TITLE
tsg の引数として include 対象を受け取るよう変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A CLI to visualize the dependencies between files in the TypeScript codebase.
 For example, the following command in the base directory of https://github.com/ysk8hori/numberplace will produce the following results:
 
 ```bash
-tsg --include src/components/atoms/ConfigMenu --exclude test stories node_modules
+tsg src/components/atoms/ConfigMenu --exclude test stories node_modules
 ```
 
 ```mermaid
@@ -62,24 +62,29 @@ flowchart
 npm install --global @ysk8hori/typescript-graph
 ```
 
+## Arguments
+
+| Argument        | Description                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `include-files` | Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`). (default: "") |
+
 ## Options
 
-Run the `tsg -h` for help
-
-```Options:
-  -V, --version            output the version number
-  --md <char>              Specify the name of the markdown file to be output. Default is typescript-graph.md.
-  --mermaid-link           Generates a link on node to open that file in VSCode.
-  -d, --dir <char>         Specify the TypeScript code base to be analyzed. if tsconfig.json is not found, specify the directory where tsconfig.json is located.
-  --include <char...>      Specify paths and file names to be included in the graph
-  --exclude <char...>      Specify the paths and file names to be excluded from the graph
-  --abstraction <char...>  Specify the path to abstract
-  --highlight <char...>    Specify the path and file name to highlight
-  --LR                     Specify Flowchart orientation Left-to-Right
-  --TB                     Specify Flowchart orientation Top-to-Bottom
-  --config-file            Specify the relative path to the config file (from cwd or specified by -d, --dir). Default is .tsgrc.json.
-  -h, --help               display help for command
-```
+| Option                    | Description                                                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `-V, --version`           | Output the version number                                                                                                           |
+| `--md <char>`             | Specify the name of the markdown file to be output. The default is typescript-graph.md.                                             |
+| `--mermaid-link`          | (experimental) Generates a link on a node to open the corresponding file in VSCode.                                                 |
+| `-d, --dir <char>`        | Specify the TypeScript codebase to be analyzed.                                                                                     |
+| `--include <char...>`     | Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`).               |
+| `--exclude <char...>`     | Specify file paths or parts of file paths to exclude from the graph (relative to the tsconfig directory, without `./`).             |
+| `--abstraction <char...>` | Specify the paths of directories to be abstracted. Abstracted directories are treated as a single node.                             |
+| `--highlight <char...>`   | Specify the path and file names to be highlighted.                                                                                  |
+| `--LR`                    | Set the flowchart orientation to Left-to-Right.                                                                                     |
+| `--TB`                    | Set the flowchart orientation to Top-to-Bottom.                                                                                     |
+| `--measure-instability`   | Enable the beta feature to measure the instability of modules.                                                                      |
+| `--config-file`           | Specify the relative path to the config file (from the current directory or as specified by -d, --dir). The default is .tsgrc.json. |
+| `-h, --help`              | Display help for the command.                                                                                                       |
 
 ## usage
 
@@ -172,12 +177,12 @@ Also, for large repositories, Mermaid may exceed the maximum amount of data that
 
 In that case, you need to narrow down the directories to include in the graph.
 
-### `--include`
+### Arguments or `--include`
 
-Use the `--include` option to narrow down the directories and files to include in the graph.
+To narrow down the directories or files included in the graph, specify the paths or parts of the paths using either the argument or the `--include` option.
 
 ```bash
-tsg --include includeFiles config
+tsg src/includeFiles config
 ```
 
 ```mermaid
@@ -242,20 +247,18 @@ flowchart
     src/main.ts-->src/includeFiles/abstractions/k.ts
 ```
 
-The dependencies of the directory specified by `--include` will be output as shown in 👆.
-However, files that depend on files under the directory specified by `--include` will remain visible.
-If there are directories or files you are not interested in, use `--exclude` to exclude them.
+As mentioned above, only the dependencies of the directories specified by the argument or the `--include` option will be output. However, the dependencies of the files under the specified directories will still be displayed. If there are directories or files you are not interested in, use the `--exclude` option to exclude them.
 
 #### Exclude Exception via Full Path Specification (Experimental)
 
-There might be scenarios where you would want to ignore dependency relations for a certain folder using `exclude`, but within that folder, there may exist some files you wish to include in the graph. In such cases, you can use `--include` to specify the full path of a particular file, effectively removing it from the exclusion list. This ensures that the specified file is not left out despite the general exclusion of its parent folder.
+There might be scenarios where you would want to ignore dependency relations for a certain folder using `exclude`, but within that folder, there may exist some files you wish to include in the graph. In such cases, you can exclude a specific file from the exclusion list by specifying its full path in the argument or with the `--include` option.
 
 ### `--exclude`
 
 Directories and files to be excluded from the graph are excluded with the `--exclude` option.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils
+tsg includeFiles config --exclude excludeFiles utils
 ```
 
 ```mermaid
@@ -307,7 +310,7 @@ Sometimes you may not be interested in the files in a directory, but wish to kee
 In such cases, use `--abstraction` to abstract the directory.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions
 ```
 
 ```mermaid
@@ -348,7 +351,7 @@ However, I would like to emphasize what I would like to see emphasized 🤔.
 Use `--highlight` to highlight nodes that need attention.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
 ```
 
 ```mermaid

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -10,7 +10,7 @@ A CLI to visualize the dependencies between files in the TypeScript codebase.
 For example, the following command in the base directory of https://github.com/ysk8hori/numberplace will produce the following results:
 
 ```bash
-tsg --include src/components/atoms/ConfigMenu --exclude test stories node_modules
+tsg src/components/atoms/ConfigMenu --exclude test stories node_modules
 ```
 
 ```mermaid
@@ -59,29 +59,32 @@ flowchart
 ## Installation
 
 ```bash
-npm install --save-dev @ysk8hori/typescript-graph
+npm install --global @ysk8hori/typescript-graph
 ```
 
-or global install.
+## Arguments
+
+| Argument        | Description                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `include-files` | Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`). (default: "") |
 
 ## Options
 
-Run the `tsg -h` for help
-
-```Options:
-  -V, --version            output the version number
-  --md <char>              Specify the name of the markdown file to be output. Default is typescript-graph.md.
-  --mermaid-link           Generates a link on node to open that file in VSCode.
-  -d, --dir <char>         Specify the TypeScript code base to be analyzed. if tsconfig.json is not found, specify the directory where tsconfig.json is located.
-  --include <char...>      Specify paths and file names to be included in the graph
-  --exclude <char...>      Specify the paths and file names to be excluded from the graph
-  --abstraction <char...>  Specify the path to abstract
-  --highlight <char...>    Specify the path and file name to highlight
-  --LR                     Specify Flowchart orientation Left-to-Right
-  --TB                     Specify Flowchart orientation Top-to-Bottom
-  --config-file            Specify the relative path to the config file (from cwd or specified by -d, --dir). Default is .tsgrc.json.
-  -h, --help               display help for command
-```
+| Option                    | Description                                                                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `-V, --version`           | Output the version number                                                                                                           |
+| `--md <char>`             | Specify the name of the markdown file to be output. The default is typescript-graph.md.                                             |
+| `--mermaid-link`          | (experimental) Generates a link on a node to open the corresponding file in VSCode.                                                 |
+| `-d, --dir <char>`        | Specify the TypeScript codebase to be analyzed.                                                                                     |
+| `--include <char...>`     | Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`).               |
+| `--exclude <char...>`     | Specify file paths or parts of file paths to exclude from the graph (relative to the tsconfig directory, without `./`).             |
+| `--abstraction <char...>` | Specify the paths of directories to be abstracted. Abstracted directories are treated as a single node.                             |
+| `--highlight <char...>`   | Specify the path and file names to be highlighted.                                                                                  |
+| `--LR`                    | Set the flowchart orientation to Left-to-Right.                                                                                     |
+| `--TB`                    | Set the flowchart orientation to Top-to-Bottom.                                                                                     |
+| `--measure-instability`   | Enable the beta feature to measure the instability of modules.                                                                      |
+| `--config-file`           | Specify the relative path to the config file (from the current directory or as specified by -d, --dir). The default is .tsgrc.json. |
+| `-h, --help`              | Display help for the command.                                                                                                       |
 
 ## usage
 
@@ -174,12 +177,12 @@ Also, for large repositories, Mermaid may exceed the maximum amount of data that
 
 In that case, you need to narrow down the directories to include in the graph.
 
-### `--include`
+### Arguments or `--include`
 
-Use the `--include` option to narrow down the directories and files to include in the graph.
+To narrow down the directories or files included in the graph, specify the paths or parts of the paths using either the argument or the `--include` option.
 
 ```bash
-tsg --include includeFiles config
+tsg src/includeFiles config
 ```
 
 ```mermaid
@@ -244,20 +247,18 @@ flowchart
     src/main.ts-->src/includeFiles/abstractions/k.ts
 ```
 
-The dependencies of the directory specified by `--include` will be output as shown in 👆.
-However, files that depend on files under the directory specified by `--include` will remain visible.
-If there are directories or files you are not interested in, use `--exclude` to exclude them.
+As mentioned above, only the dependencies of the directories specified by the argument or the `--include` option will be output. However, the dependencies of the files under the specified directories will still be displayed. If there are directories or files you are not interested in, use the `--exclude` option to exclude them.
 
 #### Exclude Exception via Full Path Specification (Experimental)
 
-There might be scenarios where you would want to ignore dependency relations for a certain folder using `exclude`, but within that folder, there may exist some files you wish to include in the graph. In such cases, you can use `--include` to specify the full path of a particular file, effectively removing it from the exclusion list. This ensures that the specified file is not left out despite the general exclusion of its parent folder.
+There might be scenarios where you would want to ignore dependency relations for a certain folder using `exclude`, but within that folder, there may exist some files you wish to include in the graph. In such cases, you can exclude a specific file from the exclusion list by specifying its full path in the argument or with the `--include` option.
 
 ### `--exclude`
 
 Directories and files to be excluded from the graph are excluded with the `--exclude` option.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils
+tsg includeFiles config --exclude excludeFiles utils
 ```
 
 ```mermaid
@@ -309,7 +310,7 @@ Sometimes you may not be interested in the files in a directory, but wish to kee
 In such cases, use `--abstraction` to abstract the directory.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions
 ```
 
 ```mermaid
@@ -350,7 +351,7 @@ However, I would like to emphasize what I would like to see emphasized 🤔.
 Use `--highlight` to highlight nodes that need attention.
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
 ```
 
 ```mermaid

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -10,7 +10,7 @@ TypeScript のコードベースにおけるファイル間の依存関係を可
 例えば、https://github.com/ysk8hori/numberplace のベースディレクトリで以下のコマンドを実行すると、以下のような結果が得られます。
 
 ```bash
-tsg --include src/components/atoms/ConfigMenu --exclude test stories node_modules
+tsg src/components/atoms/ConfigMenu --exclude test stories node_modules
 ```
 
 ```mermaid
@@ -59,29 +59,32 @@ flowchart
 ## Installation
 
 ```bash
-npm install --save-dev @ysk8hori/typescript-graph
+npm install --global @ysk8hori/typescript-graph
 ```
 
-または global install をしてください。
+## Arguments
+
+| 引数            | 説明                                                                                                                        |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `include-files` | グラフに含めるファイルパスやその一部を指定します（tsconfig ディレクトリからの相対パスで、`./`は不要です）。(デフォルト: "") |
 
 ## Options
 
-`tsg -h` でヘルプを表示します。
-
-```Options:
-  -V, --version            output the version number
-  --md <char>              Specify the name of the markdown file to be output. Default is typescript-graph.md.
-  --mermaid-link           Generates a link on node to open that file in VSCode.
-  -d, --dir <char>         Specify the TypeScript code base to be analyzed. if tsconfig.json is not found, specify the directory where tsconfig.json is located.
-  --include <char...>      Specify paths and file names to be included in the graph
-  --exclude <char...>      Specify the paths and file names to be excluded from the graph
-  --abstraction <char...>  Specify the path to abstract
-  --highlight <char...>    Specify the path and file name to highlight
-  --LR                     Specify Flowchart orientation Left-to-Right
-  --TB                     Specify Flowchart orientation Top-to-Bottom
-  --config-file            Specify the relative path to the config file (from cwd or specified by -d, --dir). Default is .tsgrc.json.
-  -h, --help               display help for command
-```
+| オプション                | 説明                                                                                                                               |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `-V, --version`           | バージョン番号を出力                                                                                                               |
+| `--md <char>`             | 出力するMarkdownファイルの名前を指定します。デフォルトは typescript-graph.md です。                                                |
+| `--mermaid-link`          | (experimental) ノードにリンクを生成し、そのファイルをVSCodeで開けるようにします。                                                  |
+| `-d, --dir <char>`        | 解析対象のTypeScriptコードベースを指定します。                                                                                     |
+| `--include <char...>`     | グラフに含めるファイルパスやその一部を指定します（tsconfig ディレクトリからの相対パスで、`./`は不要です）。                        |
+| `--exclude <char...>`     | グラフから除外するファイルパスやその一部を指定します（tsconfig ディレクトリからの相対パスで、`./`は不要です）。                    |
+| `--abstraction <char...>` | 抽象化したいディレクトリのパスを指定します。抽象化したディレクトリは一つのノードとして扱います。                                   |
+| `--highlight <char...>`   | 強調表示するパスとファイル名を指定します。                                                                                         |
+| `--LR`                    | フローチャートの向きを左から右に指定します。                                                                                       |
+| `--TB`                    | フローチャートの向きを上から下に指定します。                                                                                       |
+| `--measure-instability`   | モジュールの不安定性を測定するベータ機能を有効化します。                                                                           |
+| `--config-file`           | 設定ファイルへの相対パスを指定します（カレントディレクトリまたは -d, --dir で指定された場所から）。デフォルトは .tsgrc.json です。 |
+| `-h, --help`              | コマンドのヘルプを表示します。                                                                                                     |
 
 ## 使い方
 
@@ -174,12 +177,12 @@ flowchart
 
 その場合、グラフに含めるディレクトリを絞り込む必要があります。
 
-### `--include`
+### 引数または `--include` オプション
 
-グラフに含めるディレクトリやファイルを絞り込むには、 `--include` オプションを使用します。
+グラフに含めるディレクトリやファイルを絞り込むには、引数または `--include` オプションでパスまたはその一部を指定します。
 
 ```bash
-tsg --include includeFiles config
+tsg src/includeFiles config
 ```
 
 ```mermaid
@@ -244,21 +247,21 @@ flowchart
     src/main.ts-->src/includeFiles/abstractions/k.ts
 ```
 
-👆 のように `--include` で指定されたディレクトリの依存関係のみが、出力されるようになります。
-ただし、 `--include` で指定したディレクトリ配下のファイルの依存先は表示されたままになります。
+👆 のように引数または `--include` で指定したディレクトリの依存関係のみを、出力するようになります。
+ただし、ここで指定したディレクトリ配下のファイルの依存先は表示されたままになります。
 もし、興味のないディレクトリやファイルがある場合は、 `--exclude` を使って除外してください。
 
 #### フルパスを指定して除外対象外とする (experimental)
 
 あるフォルダに対して `exclude` を使用して依存関係を無視することが必要な場合がありますが、そのフォルダ内にグラフに含めたい一部のファイルが存在するといった状況も存在します。
-このような場合、特定のファイルについては `--include` でそのファイルの完全パスを指定することで、そのファイルを除外リストから除くことができます。
+このような場合、特定のファイルについては引数または `--include` でそのファイルの完全パスを指定することで、そのファイルを除外リストから除くことができます。
 
 ### `--exclude`
 
 グラフから除外するディレクトリやファイルは `--exclude` オプションで除外します。
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils
+tsg includeFiles config --exclude excludeFiles utils
 ```
 
 ```mermaid
@@ -310,7 +313,7 @@ flowchart
 そのような場合は、 `--abstraction` を使用して、ディレクトリを抽象化します。
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions
 ```
 
 ```mermaid
@@ -351,7 +354,7 @@ flowchart
 注意が必要なノードを強調表示するには、`--highlight` を使用します。
 
 ```bash
-tsg --include includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
+tsg includeFiles config --exclude excludeFiles utils --abstraction abstractions --highlight config.ts b.ts --LR
 ```
 
 ```mermaid

--- a/integration.spec.ts
+++ b/integration.spec.ts
@@ -114,6 +114,94 @@ test('run:sample', async () => {
   `);
 });
 
+test('run:sample:argument-include', async () => {
+  await $`ts-node -O '{\"module\": \"commonjs\"}' ./src/index.ts includeFiles config -d './dummy_project' --md ${filepath}`;
+
+  const file = fs.readFileSync(filepath, { encoding: 'utf-8' });
+  expect(file).toMatchInlineSnapshot(`
+    "# TypeScript Graph
+
+    \`\`\`bash
+    tsg includeFiles config -d ./dummy_project --md __tmp__/test.md
+    \`\`\`
+
+    \`\`\`mermaid
+    flowchart
+        subgraph src["src"]
+            src/config.ts["config.ts"]
+            src/utils.ts["utils.ts"]
+            src/main.ts["main.ts"]
+            subgraph src/includeFiles["/includeFiles"]
+                src/includeFiles/b.ts["b.ts"]
+                src/includeFiles/c.ts["c.ts"]
+                src/includeFiles/a.ts["a.ts"]
+                subgraph src/includeFiles/children["/children"]
+                    src/includeFiles/children/childA.ts["childA.ts"]
+                end
+                subgraph src/includeFiles/excludeFiles["/excludeFiles"]
+                    src/includeFiles/excludeFiles/i.ts["i.ts"]
+                    src/includeFiles/excludeFiles/g.ts["g.ts"]
+                    src/includeFiles/excludeFiles/h.ts["h.ts"]
+                    subgraph src/includeFiles/excludeFiles/style_["/style"]
+                        src/includeFiles/excludeFiles/style_/style_.ts["style.ts"]
+                    end
+                    subgraph src/includeFiles/excludeFiles/class_["/class"]
+                        src/includeFiles/excludeFiles/class_/class_A.ts["classA.ts"]
+                    end
+                end
+                subgraph src/includeFiles/d["/d"]
+                    src/includeFiles/d/d.ts["d.ts"]
+                    src/includeFiles/d/index.ts["index.ts"]
+                end
+                subgraph src/includeFiles/abstractions["/abstractions"]
+                    src/includeFiles/abstractions/j.ts["j.ts"]
+                    src/includeFiles/abstractions/l.ts["l.ts"]
+                    src/includeFiles/abstractions/k.ts["k.ts"]
+                    subgraph src/includeFiles/abstractions/children["/children"]
+                        src/includeFiles/abstractions/children/childA.ts["childA.ts"]
+                    end
+                end
+            end
+            subgraph src/otherFiles["/otherFiles"]
+                src/otherFiles/e.ts["e.ts"]
+            end
+        end
+        src/includeFiles/b.ts-->src/utils.ts
+        src/includeFiles/b.ts-->src/config.ts
+        src/includeFiles/c.ts-->src/utils.ts
+        src/includeFiles/c.ts-->src/includeFiles/b.ts
+        src/config.ts-->src/utils.ts
+        src/config.ts-->src/includeFiles/c.ts
+        src/includeFiles/children/childA.ts-->src/utils.ts
+        src/includeFiles/excludeFiles/i.ts-->src/utils.ts
+        src/includeFiles/d/index.ts-->src/includeFiles/d/d.ts
+        src/includeFiles/a.ts-->src/includeFiles/children/childA.ts
+        src/includeFiles/a.ts-->src/includeFiles/excludeFiles/g.ts
+        src/includeFiles/a.ts-->src/includeFiles/excludeFiles/i.ts
+        src/includeFiles/a.ts-->src/includeFiles/excludeFiles/style_/style_.ts
+        src/includeFiles/a.ts-->src/includeFiles/excludeFiles/class_/class_A.ts
+        src/includeFiles/a.ts-->src/includeFiles/excludeFiles/h.ts
+        src/includeFiles/a.ts-->src/includeFiles/d/index.ts
+        src/includeFiles/a.ts-->src/utils.ts
+        src/otherFiles/e.ts-->src/config.ts
+        src/includeFiles/abstractions/j.ts-->src/utils.ts
+        src/includeFiles/abstractions/j.ts-->src/includeFiles/abstractions/children/childA.ts
+        src/includeFiles/abstractions/j.ts-->data.json
+        src/includeFiles/abstractions/l.ts-->src/utils.ts
+        src/includeFiles/abstractions/k.ts-->src/includeFiles/abstractions/l.ts
+        src/includeFiles/abstractions/k.ts-->src/utils.ts
+        src/main.ts-->src/includeFiles/a.ts
+        src/main.ts-->src/includeFiles/b.ts
+        src/main.ts-->src/includeFiles/abstractions/j.ts
+        src/main.ts-->src/includeFiles/abstractions/k.ts
+        src/otherFiles/e.ts-->src/utils.ts
+        src/main.ts-->src/otherFiles/e.ts
+        src/main.ts-->src/utils.ts
+    \`\`\`
+    "
+  `);
+});
+
 test('run:sample:include', async () => {
   await $`ts-node -O '{\"module\": \"commonjs\"}' ./src/index.ts -d './dummy_project' --include includeFiles config --md ${filepath}`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ program
   .description(packagejson.description)
   .version(packagejson.version);
 program
+  .argument(
+    '[include-files]',
+    'Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`).',
+    '',
+  )
   .option(
     '--md <char>',
     'Specify the name of the markdown file to be output. Default is typescript-graph.md.',
@@ -32,11 +37,11 @@ program
   )
   .option(
     '--include <char...>',
-    'Specify paths and file names to be included in the graph',
+    'Specify file paths or parts of file paths to include in the graph (relative to the tsconfig directory, without `./`).',
   )
   .option(
     '--exclude <char...>',
-    'Specify the paths and file names to be excluded from the graph',
+    'Specify file paths or parts of file paths to exclude from the graph (relative to the tsconfig directory, without `./`).',
   )
   .option('--abstraction <char...>', 'Specify the path to abstract')
   .option(
@@ -56,6 +61,9 @@ program
 program.parse();
 
 const opt = program.opts<Partial<OptionValues>>();
+// tsg の arguments と --include オプションをマージする
+opt.include = [...program.args, ...(opt.include ?? [])];
+opt.include = opt.include.length === 0 ? undefined : opt.include;
 
 export async function main(
   dir: string,
@@ -63,7 +71,7 @@ export async function main(
 ) {
   setupConfig(path.join(dir, commandOptions.configFile ?? '.tsgrc.json'));
 
-  const { graph: fullGraph, meta } = createGraph(dir);
+  const { graph: fullGraph, meta } = createGraph(dir, commandOptions);
 
   let couplingData: ReturnType<typeof measureInstability> = [];
   if (commandOptions.measureInstability) {


### PR DESCRIPTION
また、マイナーチェンジとして [exclude 対象をソースファイル読み込み前に除外する](https://github.com/ysk8hori/typescript-graph/commit/24cfe5d0050d850f1f3ab6751e1fd34fe6fb33ab) 変更も。