### PR TITLE
fix(abstraction): abstraction でファイルを指定した際の出力でファイルがdirの見た目になるバグを修正

### DIFF
--- a/src/graph/abstraction.spec.ts
+++ b/src/graph/abstraction.spec.ts
@@ -47,3 +47,50 @@ it('指定したディレクトリを抽象化できる', () => {
     }
   `);
 });
+
+it('ファイル名を指定した場合、その対象はディレクトリ扱いにならない', () => {
+  expect(
+    abstraction(['src/a/b', 'src/a/b/c', 'src/a/a.ts'], {
+      nodes: [
+        {
+          path: 'src/a/a.ts',
+          name: 'a.ts',
+          changeStatus: 'not_modified',
+        },
+        {
+          path: 'src/a/b/b.ts',
+          name: 'b.ts',
+          changeStatus: 'not_modified',
+        },
+        {
+          path: 'src/a/b/c/c.ts',
+          name: 'c.ts',
+          changeStatus: 'not_modified',
+        },
+        {
+          path: 'src/a/b/c/d/d.ts',
+          name: 'd.ts',
+          changeStatus: 'not_modified',
+        },
+      ],
+      relations: [],
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "nodes": [
+        {
+          "changeStatus": "not_modified",
+          "name": "a.ts",
+          "path": "src/a/a.ts",
+        },
+        {
+          "changeStatus": "not_modified",
+          "isDirectory": true,
+          "name": "/b",
+          "path": "src/a/b",
+        },
+      ],
+      "relations": [],
+    }
+  `);
+});

--- a/src/graph/abstraction.ts
+++ b/src/graph/abstraction.ts
@@ -64,7 +64,7 @@ export function abstraction(
 
 function abstractionNode(node: Node, absDirArrArr: string[][]): Node {
   const absDirArr = getAbstractionDirArr(absDirArrArr, node);
-  if (!absDirArr) return node;
+  if (!absDirArr || absDirArr.at(-1) === node.name) return node;
   return {
     name: `/${absDirArr.at(-1)!}`,
     path: abstractionPath(node.path, absDirArr),


### PR DESCRIPTION
## before

```bash
tsg src --abstraction src/config src/graph src/index.ts src/mermaidify.fileNameToMermaidId.spec.ts src/mermaidify.ts src/models.ts src/reset.d.ts src/typescript-compiler-api-demo.ts src/writeMarkdownFile.ts
```

```mermaid
flowchart
    classDef dir fill:#0000,stroke:#999
    subgraph src["src"]
        src/models.ts["/models.ts"]:::dir
        src/graph_["/graph"]:::dir
        src/config["/config"]:::dir
        src/mermaidify.ts["/mermaidify.ts"]:::dir
        src/writeMarkdownFile.ts["/writeMarkdownFile.ts"]:::dir
        src/index.ts["/index.ts"]:::dir
        src/reset.d.ts["/reset.d.ts"]:::dir
        src/typescript//compiler//api//demo.ts["/typescript-compiler-api-demo.ts"]:::dir
    end
    src/graph_-->src/models.ts
    src/mermaidify.ts-->src/models.ts
    src/mermaidify.ts-->src/config
    src/writeMarkdownFile.ts-->src/mermaidify.ts
    src/writeMarkdownFile.ts-->src/models.ts
    src/index.ts-->src/graph_
    src/index.ts-->src/writeMarkdownFile.ts
    src/index.ts-->package.json
    src/index.ts-->src/models.ts
    src/index.ts-->src/config
```

## after

```mermaid
flowchart
    classDef dir fill:#0000,stroke:#999
    subgraph src["src"]
        src/models.ts["models.ts"]
        src/graph_["/graph"]:::dir
        src/config["/config"]:::dir
        src/mermaidify.ts["mermaidify.ts"]
        src/writeMarkdownFile.ts["writeMarkdownFile.ts"]
        src/index.ts["index.ts"]
        src/reset.d.ts["reset.d.ts"]
        src/typescript//compiler//api//demo.ts["typescript-compiler-api-demo.ts"]
    end
    src/graph_-->src/models.ts
    src/mermaidify.ts-->src/models.ts
    src/mermaidify.ts-->src/config
    src/writeMarkdownFile.ts-->src/mermaidify.ts
    src/writeMarkdownFile.ts-->src/models.ts
    src/index.ts-->src/graph_
    src/index.ts-->src/writeMarkdownFile.ts
    src/index.ts-->package.json
    src/index.ts-->src/models.ts
    src/index.ts-->src/config
```
