### PR TITLE
fix: enable lockFileMaintenance in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,10 @@
     },
   ],
   automerge: true,
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ['after 5pm and before 10pm on Thursday'],
+  },
   ignoreDeps: [
     'chalk', // 要 esm 対応 @see https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
   ],


### PR DESCRIPTION
## Summary
- Add `lockFileMaintenance` configuration to renovate.json5 to ensure renovate properly updates package-lock.json when updating dependencies
- This fixes the issue where renovate was only updating package.json but not the corresponding lock file, causing CI failures due to package.json and package-lock.json being out of sync

## Test plan
- [x] Merge this PR
- [ ] Wait for renovate to run and verify that future dependency updates include both package.json and package-lock.json changes
- [ ] Verify that CI builds pass for renovate PRs

🤖 Generated with [Claude Code](https://claude.ai/code)